### PR TITLE
fix: replace subjects relation with subject & rm informationModel relation

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/mapper/DatasetMapper.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/mapper/DatasetMapper.kt
@@ -44,10 +44,6 @@ fun Dataset.getRelations(): List<Relation> {
         relations.add(Relation(uri = it.uri, type = RelationType.inSeries))
     }
 
-    informationModel?.forEach {
-        relations.add(Relation(uri = it.uri, type = RelationType.informationModel))
-    }
-
     references?.forEach {
         relations.add(Relation(uri = it.source?.uri, type = it.uriToRelationType() ?: RelationType.relation))
     }

--- a/src/main/kotlin/no/digdir/fdk/searchservice/mapper/InformationModelMapper.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/mapper/InformationModelMapper.kt
@@ -45,7 +45,7 @@ fun InformationModel.getRelations(): List<Relation> {
 
 
     subjects?.forEach {
-        relations.add(Relation(uri = it, type = RelationType.subjects))
+        relations.add(Relation(uri = it, type = RelationType.subject))
     }
 
     return relations

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/Dataset.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/Dataset.kt
@@ -23,7 +23,6 @@ data class Dataset(
     val distribution: List<Distribution>?,
     val conformsTo: List<ObjectWithURI>?,
     val inSeries: ObjectWithURI?,
-    val informationModel: List<ObjectWithURI>?,
     val references: List<Reference>?,
     val subject: List<ObjectWithURI>?
 )

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/SearchObject.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/SearchObject.kt
@@ -58,7 +58,6 @@ enum class RelationType {
     subject,
     hasPart,
     isPartOf,
-    subjects,
     isGroupedBy,
     isClassifiedBy,
     isDescribedAt,

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/SearchObject.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/SearchObject.kt
@@ -54,7 +54,6 @@ enum class RelationType {
     conformsTo,
     servesDataset,
     inSeries,
-    informationModel,
     subject,
     hasPart,
     isPartOf,

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/DatasetTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/DatasetTestData.kt
@@ -26,7 +26,6 @@ val TEST_NULL_DATASET = Dataset(
     subject = null,
     conformsTo = null,
     inSeries = null,
-    informationModel = null,
     references = null
 )
 
@@ -203,7 +202,6 @@ val DATASET_WITH_RELATIONS = TEST_NULL_DATASET.copy(
     subject = listOf(ObjectWithURI(uri = "subject_uri")),
     conformsTo = listOf(ObjectWithURI(uri = "conformsTo_uri")),
     inSeries = ObjectWithURI(uri = "inSeries_uri"),
-    informationModel = listOf(ObjectWithURI(uri = "informationModel_uri")),
     references = listOf(
         Reference(referenceType = ReferenceDataCode(code = null, prefLabel = null, uri = "$basePath/source"), source = (ObjectWithURI(uri = "source_uri"))),
         Reference(referenceType = ReferenceDataCode(code = null, prefLabel = null, uri = "$basePath/hasVersion"), source = (ObjectWithURI(uri = "has_version_uri"))),

--- a/src/test/kotlin/no/digdir/fdk/searchservice/unit/RelationsMappingTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/unit/RelationsMappingTest.kt
@@ -70,7 +70,7 @@ val expectedInformationModelRelations = listOf(
     Relation(uri = "hasPart_uri", type=RelationType.hasPart),
     Relation(uri = "isReplacedBy_uri", type=RelationType.isReplacedBy),
     Relation(uri = "isPartOf_uri", type=RelationType.isPartOf),
-    Relation(uri = "subjects_uri", type=RelationType.subjects)
+    Relation(uri = "subjects_uri", type=RelationType.subject)
 )
 
 val expectedConceptRelations = listOf(

--- a/src/test/kotlin/no/digdir/fdk/searchservice/unit/RelationsMappingTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/unit/RelationsMappingTest.kt
@@ -45,7 +45,6 @@ val expectedDatasetRelations = listOf(
     Relation(uri = "subject_uri", type=RelationType.subject),
     Relation(uri = "conformsTo_uri", type=RelationType.conformsTo),
     Relation(uri = "inSeries_uri", type=RelationType.inSeries),
-    Relation(uri = "informationModel_uri", type=RelationType.informationModel),
     Relation(uri = "source_uri", type=RelationType.source),
     Relation(uri = "has_version_uri", type=RelationType.hasVersion),
     Relation(uri = "is_version_of_uri", type=RelationType.isVersionOf),


### PR DESCRIPTION
subjects er egentlig samme relasjon som subject, bytter den ut med det

informationModel ble for lenge siden bytta ut med conformsTo i dcat-ap-no. Hørte med Kurt Stian, siden den heller ikke blir brukt i prod så fjerner vi bare støtte for den