### PR TITLE
fix: include missing no field in language objects

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonDataClasses.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonDataClasses.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class LocalizedStrings(
     val nb: String?,
     val nn: String?,
+    val no: String?,
     val en: String?
 )
 

--- a/src/main/kotlin/no/digdir/fdk/searchservice/service/SearchService.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/service/SearchService.kt
@@ -324,6 +324,7 @@ class SearchService(
     private fun languagePaths(basePath: String, boost: Int? = null): List<String> =
         listOf("$basePath.nb${if (boost != null) "^$boost" else ""}",
             "$basePath.nn${if (boost != null) "^$boost" else ""}",
+            "$basePath.no${if (boost != null) "^$boost" else ""}",
             "$basePath.en${if (boost != null) "^$boost" else ""}")
 
     private fun StringTermsAggregate.toBucketCounts(): List<BucketCount> =

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/ConceptTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/ConceptTestData.kt
@@ -30,35 +30,41 @@ val TEST_CONCEPT_HIT_ALL_FIELDS = TEST_NULL_CONCEPT.copy(
         prefLabel = LocalizedStrings(
             "NB Test publisher > prefLabel",
             "NN Test publisher > prefLabel",
+            "NO Test publisher > prefLabel",
             "EN Test publisher > prefLabel"),
     ),
     definition = Definition(
         LocalizedStrings(
             "NB Test definition > text",
             "NN Test definition > text",
+            "NO Test definition > text",
             "EN Test definition > text"),
         listOf(TextAndURI(LocalizedStrings(
             "NB Test definition > sources > text",
             "NN Test definition > sources > text",
+            "NO Test definition > sources > text",
             "EN Test definition > sources > text"))),
         "Test definition > sourceRelationship"),
     prefLabel = LocalizedStrings(
         "NB Test prefLabel, title",
         "NN Test prefLabel",
+        "NO Test prefLabel, title",
         "EN Test prefLabel"),
-    harvest =  HarvestMetadata(
+    harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
-            listOf("Test harvest > changed")),
+        listOf("Test harvest > changed")),
     collection = Collection(
         id = "Test collection > id 1021",
         uri = "Test collection > uri 1021",
         label = LocalizedStrings(
             "NB Test collection > label",
             "NN Test collection > label",
+            "NO Test collection > label",
             "EN Test collection > label"),
         description = LocalizedStrings(
             "NB Test collection > description",
             "NN Test collection > description",
+            "NO Test collection > description",
             "EN Test collection > description"),
         publisher = Organization(
             orgPath = "/KOMMUNE/102117858",
@@ -68,7 +74,8 @@ val TEST_CONCEPT_HIT_ALL_FIELDS = TEST_NULL_CONCEPT.copy(
             prefLabel = LocalizedStrings(
                 "NB Test publisher > prefLabel",
                 "NN Test publisher > prefLabel",
-            "EN Test publisher > prefLabel"))
+                "NO Test publisher > prefLabel",
+                "EN Test publisher > prefLabel"))
     ),
 )
 

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/DataServiceTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/DataServiceTestData.kt
@@ -28,6 +28,7 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
         prefLabel = LocalizedStrings(
             "NB Test publisher > prefLabel",
             "NN Test publisher > prefLabel",
+            "NO Test publisher > prefLabel",
             "EN Test publisher > prefLabel"),
     ),
     accessRights = ReferenceDataCode(
@@ -36,6 +37,7 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
         prefLabel = LocalizedStrings(
             "accessRights > NB Public",
             "accessRights> NN Public",
+            "accessRights > NO Public",
             "accessRights > EN Public"),
     ),
     theme = listOf(
@@ -43,12 +45,14 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "ENVI"),
         EuDataTheme(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "REGI")
     ),
@@ -57,6 +61,7 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
             name = LocalizedStrings(
                 "NB Test losTheme > name",
                 "NN Test losTheme > name",
+                "NO Test losTheme > name",
                 "EN Test losTheme > name"),
             losPaths = listOf("familie-og-barn"),
         )
@@ -65,12 +70,14 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
         description = LocalizedStrings(
             "NB Test catalog > description",
             "NN Test catalog > description",
+            "NO Test catalog > description",
             "EN Test catalog > description"),
         id = "Test catalog > id",
         uri = "Test catalog > uri",
         title = LocalizedStrings(
             "NB Test catalog > title",
             "NN Test catalog > title",
+            "NO Test catalog > title",
             "EN Test catalog > title"),
         publisher = Organization(
             orgPath = "/PRIVAT/172417858",
@@ -80,27 +87,32 @@ val TEST_DATA_SERVICE_HIT_ALL_FIELDS = TEST_NULL_DATA_SERVICE.copy(
             prefLabel = LocalizedStrings(
                 "NB Test publisher > prefLabel",
                 "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
                 "EN Test publisher > prefLabel"),
         )),
     title = LocalizedStrings(
         "NB Test prefLabel, title",
         "NN Test prefLabel",
+        "NO Test prefLabel, title",
         "EN Test prefLabel"),
-    harvest =  HarvestMetadata(
+    harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
         listOf("Test harvest > changed")),
     description = LocalizedStrings(
         "NB Test collection > description",
         "NN Test collection > description",
+        "NO Test collection > description",
         "EN Test collection > description"),
     keyword = listOf(
         LocalizedStrings(
             "NB Test keyword > prefLabel",
             "NN Test keyword > prefLabel",
+            "NO Test keyword > prefLabel",
             "EN Test keyword > prefLabel"),
         LocalizedStrings(
             "NB Test keyword > prefLabel",
             "NN Test keyword > prefLabel",
+            "NO Test keyword > prefLabel",
             "EN Test keyword > prefLabel")
     ),
     fdkFormat = listOf(

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/DatasetTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/DatasetTestData.kt
@@ -32,15 +32,18 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
     title = LocalizedStrings(
         "NB Test title",
         "NN Test title",
+        "NO Test title",
         "EN Test title"),
     description = LocalizedStrings(
         "NB Test description",
         "NN Test description",
+        "NO Test description",
         "EN Test description"),
     keyword = listOf(
         LocalizedStrings(
             "NB Test keyword",
             "NN Test keyword",
+            "NO Test keyword",
             "EN Test keyword")
     ),
     theme = listOf(
@@ -48,12 +51,14 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "ENVI"),
         EuDataTheme(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "REGI")
     ),
@@ -62,6 +67,7 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
             name = LocalizedStrings(
                 "NB Test losTheme > name",
                 "NN Test losTheme > name",
+                "NO Test losTheme > name",
                 "EN Test losTheme > name"),
             losPaths = listOf("familie-og-barn"),
         )
@@ -74,6 +80,7 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
         prefLabel = LocalizedStrings(
             "NB Test publisher > prefLabel",
             "NN Test publisher > prefLabel",
+            "NO Test publisher > prefLabel",
             "EN Test publisher > prefLabel"),
     ),
     accessRights = ReferenceDataCode(
@@ -82,6 +89,7 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
         prefLabel = LocalizedStrings(
             "NB Test accessRights > prefLabel",
             "NN Test accessRights > prefLabel",
+            "NO Test accessRights > prefLabel",
             "EN Test accessRights > prefLabel")
     ),
     spatial = listOf(
@@ -91,6 +99,7 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
             prefLabel = LocalizedStrings(
                 "NB Test spatial > prefLabel",
                 "NN Test spatial > prefLabel",
+                "NO Test spatial > prefLabel",
                 "EN Test spatial > prefLabel")
         )
     ),
@@ -100,24 +109,27 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
         prefLabel = LocalizedStrings(
             "NB Test provenance > prefLabel",
             "NN Test provenance > prefLabel",
+            "NO Test provenance > prefLabel",
             "EN Test provenance > prefLabel")
     ),
     harvest = HarvestMetadata(
-            firstHarvested = LocalDateTime.now().minusDays(2).format(DateTimeFormatter.ISO_LOCAL_DATE),
-            changed = listOf(
-                    "Test harvest > changed 1",
-                    "Test harvest > changed 2")
+        firstHarvested = LocalDateTime.now().minusDays(2).format(DateTimeFormatter.ISO_LOCAL_DATE),
+        changed = listOf(
+            "Test harvest > changed 1",
+            "Test harvest > changed 2")
     ),
     catalog = Catalog(
         description = LocalizedStrings(
             "NB Test catalog > description",
             "NN Test catalog > description",
+            "NO Test catalog > description",
             "EN Test catalog > description"),
         id = "Test catalog > id",
         uri = "Test catalog > uri",
         title = LocalizedStrings(
             "NB Test catalog > title",
             "NN Test catalog > title",
+            "NO Test catalog > title",
             "EN Test catalog > title"),
         publisher = Organization(
             orgPath = "/PRIVAT/172417858",
@@ -127,6 +139,7 @@ val TEST_DATASET_HIT_ALL_FIELDS = TEST_NULL_DATASET.copy(
             prefLabel = LocalizedStrings(
                 "NB Test publisher > prefLabel",
                 "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
                 "EN Test publisher > prefLabel"),
         ))
 )
@@ -140,6 +153,7 @@ val TEST_DATASET_FILTERS = TEST_DATASET_HIT_ALL_FIELDS.copy(
         prefLabel = LocalizedStrings(
             "Bruker",
             "Brukar",
+            "Bruker",
             "User")
     ),
     spatial = listOf(
@@ -149,17 +163,18 @@ val TEST_DATASET_FILTERS = TEST_DATASET_HIT_ALL_FIELDS.copy(
             prefLabel = LocalizedStrings(
                 "Norge",
                 "Noreg",
+                "Norge",
                 "Norway")
         ),
         ReferenceDataCode(
             uri = "spatial > uri",
             code = "123456",
-            prefLabel = LocalizedStrings(nb = "Spania", null ,null )
+            prefLabel = LocalizedStrings(nb = "Spania", null, null, null)
         ),
         ReferenceDataCode(
             uri = "spatial > uri",
             code = "56789",
-            prefLabel = LocalizedStrings(nb = "Sogn og fjordane", null ,null )
+            prefLabel = LocalizedStrings(nb = "Sogn og fjordane", null, null, null)
         )
     ),
     losTheme = listOf(
@@ -181,17 +196,17 @@ val TEST_DATASET_FILTERS = TEST_DATASET_HIT_ALL_FIELDS.copy(
     ),
     distribution = listOf(
         Distribution(
-        listOf(
-            MediaTypeOrExtent(name = null, uri = null, type = MediaTypeOrExtentType.MEDIA_TYPE, code = "tiff"),
-            MediaTypeOrExtent(name = null, uri = null, type = MediaTypeOrExtentType.FILE_TYPE, code = "SHP")
-        ))
+            listOf(
+                MediaTypeOrExtent(name = null, uri = null, type = MediaTypeOrExtentType.MEDIA_TYPE, code = "tiff"),
+                MediaTypeOrExtent(name = null, uri = null, type = MediaTypeOrExtentType.FILE_TYPE, code = "SHP")
+            ))
     )
 )
 
 val TEST_DATASET_HIT_IS_OPEN = TEST_DATASET_HIT_ALL_FIELDS.copy(
     uri = "dataset.uri.2",
     isOpenData = true,
-    conformsTo = listOf(ObjectWithURI(uri=TEST_DATASET_FILTERS.uri))
+    conformsTo = listOf(ObjectWithURI(uri = TEST_DATASET_FILTERS.uri))
 )
 
 val basePath = "http://purl.org/dc/terms"

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/EventTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/EventTestData.kt
@@ -15,51 +15,58 @@ val TEST_EVENT = TEST_NULL_EVENT.copy(
     title = LocalizedStrings(
         "NB Test prefLabel, title",
         "NN Test prefLabel",
+        "NO Test prefLabel, title",
         "EN Test prefLabel"),
-    harvest =  HarvestMetadata(
+    harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
         listOf("Test harvest > changed")),
     description = LocalizedStrings(
         "NB Test collection > description",
         "NN Test collection > description",
+        "NO Test collection > description",
         "EN Test collection > description"),
 )
 
 val TEST_EVENT_HIT_ALL_FIELDS = TEST_NULL_EVENT.copy(
-        uri = "uri 1061",
-        title = LocalizedStrings(
-                "NB title",
-                "NN title",
-                "EN title"),
-        catalog = Catalog(
-                description = LocalizedStrings(
-                        "NB Test catalog > description",
-                        "NN Test catalog > description",
-                        "EN Test catalog > description"),
-                id = "Test catalog > id 1061",
-                uri = "Test catalog > uri 1061",
-                title = LocalizedStrings(
-                        "NB Test catalog > title",
-                        "NN Test catalog > title",
-                        "EN Test catalog > title"),
-                publisher = Organization(
-                        orgPath = "/PRIVAT/106117858",
-                        identifier = "Test publisher > identifier",
-                        uri = "Test publisher > uri",
-                        name = "Test publisher > name",
-                        prefLabel = LocalizedStrings(
-                                "NB Test publisher > prefLabel",
-                                "NN Test publisher > prefLabel",
-                                "EN Test publisher > prefLabel"),
-                ),
-        ),
+    uri = "uri 1061",
+    title = LocalizedStrings(
+        "NB title",
+        "NN title",
+        "NO title",
+        "EN title"),
+    catalog = Catalog(
         description = LocalizedStrings(
-                "NB Test description",
-                "NN Test description",
-                "EN Test description"),
-        harvest =  HarvestMetadata(
-            "2022-02-15T11:00:05Z",
-                listOf("Test harvest > changed")),
+            "NB Test catalog > description",
+            "NN Test catalog > description",
+            "NO Test catalog > description",
+            "EN Test catalog > description"),
+        id = "Test catalog > id 1061",
+        uri = "Test catalog > uri 1061",
+        title = LocalizedStrings(
+            "NB Test catalog > title",
+            "NN Test catalog > title",
+            "NO Test catalog > title",
+            "EN Test catalog > title"),
+        publisher = Organization(
+            orgPath = "/PRIVAT/106117858",
+            identifier = "Test publisher > identifier",
+            uri = "Test publisher > uri",
+            name = "Test publisher > name",
+            prefLabel = LocalizedStrings(
+                "NB Test publisher > prefLabel",
+                "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
+                "EN Test publisher > prefLabel"),
+        ),
+    ),
+    description = LocalizedStrings(
+        "NB Test description",
+        "NN Test description",
+        "NO Test description",
+        "EN Test description"),
+    harvest = HarvestMetadata(
+        "2022-02-15T11:00:05Z",
+        listOf("Test harvest > changed")),
 )
 
 val EVENT_WITH_RELATIONS = TEST_NULL_EVENT.copy(subject = listOf("subject_uri"))

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/InformationModelTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/InformationModelTestData.kt
@@ -26,17 +26,20 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
     title = LocalizedStrings(
         "NB title",
         "NN title",
+        "NO title",
         "EN title"),
     catalog = Catalog(
         description = LocalizedStrings(
             "NB Test catalog > description",
             "NN Test catalog > description",
+            "NO Test catalog > description",
             "EN Test catalog > description"),
         id = "Test catalog > id",
         uri = "Test catalog > uri",
         title = LocalizedStrings(
             "NB Test catalog > title",
             "NN Test catalog > title",
+            "NO Test catalog > title",
             "EN Test catalog > title"),
         publisher = Organization(
             orgPath = "/PRIVAT/108117858",
@@ -46,17 +49,20 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
             prefLabel = LocalizedStrings(
                 "NB Test publisher > prefLabel",
                 "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
                 "EN Test publisher > prefLabel"),
         ),
     ),
     description = LocalizedStrings(
         "NB Test description",
         "NN Test description",
+        "NO Test description",
         "EN Test description"),
     keyword = listOf(
         LocalizedStrings(
             "NB Test keyword",
             "NN Test keyword",
+            "NO Test keyword",
             "EN Test keyword")
     ),
     theme = listOf(
@@ -64,12 +70,14 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "ENVI"),
         EuDataTheme(
             title = LocalizedStrings(
                 "NB Test theme > title",
                 "NN Test theme > title",
+                "NO Test theme > title",
                 "EN Test theme > title"),
             code = "REGI")
     ),
@@ -78,6 +86,7 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
             name = LocalizedStrings(
                 "NB Test losTheme > name",
                 "NN Test losTheme > name",
+                "NO Test losTheme > name",
                 "EN Test losTheme > name"),
             losPaths = listOf("test"),
         )
@@ -90,6 +99,7 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
         prefLabel = LocalizedStrings(
             "NB Test publisher > prefLabel",
             "NN Test publisher > prefLabel",
+            "NO Test publisher > prefLabel",
             "EN Test publisher > prefLabel"),
     ),
     accessRights = ReferenceDataCode(
@@ -98,11 +108,12 @@ val TEST_INFORMATION_MODEL_HIT_ALL_FIELDS = TEST_NULL_INFORMATION_MODEL.copy(
         prefLabel = LocalizedStrings(
             "NB Test accessRights > prefLabel",
             "NN Test accessRights > prefLabel",
+            "NO Test accessRights > prefLabel",
             "EN Test accessRights > prefLabel"),
     ),
-    harvest =  HarvestMetadata(
+    harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
-            listOf("Test harvest > changed")),
+        listOf("Test harvest > changed")),
 )
 
 val INFORMATION_MODEL_WITH_RELATIONS = TEST_NULL_INFORMATION_MODEL.copy(

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/SearchObjectTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/SearchObjectTestData.kt
@@ -32,6 +32,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
         prefLabel = LocalizedStrings(
             "NB Test accessRights > prefLabel",
             "NN Test accessRights > prefLabel",
+            "NO Test accessRights > prefLabel",
             "EN Test accessRights > prefLabel"
         )
     ),
@@ -41,6 +42,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
         description = LocalizedStrings(
             "NB Test catalog > description",
             "NN Test catalog > description",
+            "NO Test catalog > description",
             "EN Test catalog > description"
         ),
         publisher = Organization(
@@ -51,12 +53,14 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
             prefLabel = LocalizedStrings(
                 "NB Test publisher > prefLabel",
                 "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
                 "EN Test publisher > prefLabel"
             ),
         ),
         title = LocalizedStrings(
             "NB Test catalog > title",
             "NN Test catalog > title",
+            "NO Test catalog > title",
             "EN Test catalog > title"
         )
     ),
@@ -65,6 +69,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
             title = LocalizedStrings(
                 "NB Test dataTheme",
                 "NN Test dataTheme",
+                "NO Test dataTheme",
                 "EN Test dataTheme"
             ),
             code = "Test dataTheme > code"
@@ -73,6 +78,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
     description = LocalizedStrings(
         "NB Test description",
         "NN Test description",
+        "NO Test description",
         "EN Test description"
     ),
     fdkFormatPrefixed = setOf("Test fdkFormatPrefixed"),
@@ -89,6 +95,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
         LocalizedStrings(
             "NB Test keyword",
             "NN Test keyword",
+            "NO Test keyword",
             "EN Test keyword"
         )
     ),
@@ -97,6 +104,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
             LocalizedStrings(
                 "NB Test losTheme > name 1",
                 "NN Test losTheme > name 1",
+                "NO Test losTheme > name 1",
                 "EN Test losTheme > name 1"
             ),
             losPaths = null
@@ -105,6 +113,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
             LocalizedStrings(
                 "NB Test losTheme > name 2",
                 "NN Test losTheme > name 2",
+                "NO Test losTheme > name 2",
                 "EN Test losTheme > name 2"
             ),
             losPaths = listOf("Test")
@@ -118,6 +127,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
         prefLabel = LocalizedStrings(
             "NB Test publisher > prefLabel",
             "NN Test publisher > prefLabel",
+            "NO Test publisher > prefLabel",
             "EN Test publisher > prefLabel"
         ),
     ),
@@ -127,6 +137,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
         prefLabel = LocalizedStrings(
             "NB Test provenance > prefLabel",
             "NN Test provenance > prefLabel",
+            "NO Test provenance > prefLabel",
             "EN Test provenance > prefLabel"
         )
     ),
@@ -137,6 +148,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
             prefLabel = LocalizedStrings(
                 "NB Test spatial > prefLabel",
                 "NN Test spatial > prefLabel",
+                "NO Test spatial > prefLabel",
                 "EN Test spatial > prefLabel"
             )
         )
@@ -144,6 +156,7 @@ val TEST_SEARCH_OBJECT_AND_HIT_ALL_FIELDS = TEST_NULL_SEARCH_OBJECT.copy(
     title = LocalizedStrings(
         "NB Test title",
         "NN Test title",
+        "NO Test title",
         "EN Test title"
     ),
 )

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
@@ -26,119 +26,133 @@ val TEST_SERVICE = TEST_NULL_SERVICE.copy(
     title = LocalizedStrings(
         "NB Test prefLabel, title",
         "NN Test prefLabel",
+        "NO Test prefLabel, title",
         "EN Test prefLabel"),
-    harvest =  HarvestMetadata(
+    harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
         listOf("Test harvest > changed")),
     description = LocalizedStrings(
         "NB Test collection > description",
         "NN Test collection > description",
+        "NO Test collection > description",
         "EN Test collection > description"),
 )
 
 val TEST_SERVICE_HIT_ALL_FIELDS = TEST_NULL_SERVICE.copy(
-        uri = "uri 0101",
-        title = LocalizedStrings(
-                "NB title",
-                "NN title",
-                "EN title"),
-        catalog = Catalog(
-                description = LocalizedStrings(
-                        "NB Test catalog > description",
-                        "NN Test catalog > description",
-                        "EN Test catalog > description"),
-                id = "Test catalog > id 101",
-                uri = "Test catalog > uri 101",
-                title = LocalizedStrings(
-                        "NB Test catalog > title",
-                        "NN Test catalog > title",
-                        "EN Test catalog > title"),
-                publisher = Organization(
-                        orgPath = "/PRIVAT/101417858",
-                        identifier = "Test publisher > identifier 101",
-                        uri = "Test publisher > uri 101",
-                        name = "Test publisher > name",
-                        prefLabel = LocalizedStrings(
-                                "NB Test publisher > prefLabel",
-                                "NN Test publisher > prefLabel",
-                                "EN Test publisher > prefLabel"),
-                ),
-        ),
+    uri = "uri 0101",
+    title = LocalizedStrings(
+        "NB title",
+        "NN title",
+        "NO title",
+        "EN title"),
+    catalog = Catalog(
         description = LocalizedStrings(
-                "NB Test description",
-                "NN Test description",
-                "EN Test description"),
-        keyword = listOf(
-                LocalizedStrings(
-                        "NB Test keyword",
-                        "NN Test keyword",
-                        "EN Test keyword")
+            "NB Test catalog > description",
+            "NN Test catalog > description",
+            "NO Test catalog > description",
+            "EN Test catalog > description"),
+        id = "Test catalog > id 101",
+        uri = "Test catalog > uri 101",
+        title = LocalizedStrings(
+            "NB Test catalog > title",
+            "NN Test catalog > title",
+            "NO Test catalog > title",
+            "EN Test catalog > title"),
+        publisher = Organization(
+            orgPath = "/PRIVAT/101417858",
+            identifier = "Test publisher > identifier 101",
+            uri = "Test publisher > uri 101",
+            name = "Test publisher > name",
+            prefLabel = LocalizedStrings(
+                "NB Test publisher > prefLabel",
+                "NN Test publisher > prefLabel",
+                "NO Test publisher > prefLabel",
+                "EN Test publisher > prefLabel"),
         ),
-        euDataThemes = listOf(
-                EuDataTheme(
-                        title = LocalizedStrings(
-                                "NB Test euDataThemes > title",
-                                "NN Test euDataThemes > title",
-                                "EN Test euDataThemes > title"),
-                        code = "ENVI"),
-                EuDataTheme(
-                        title = LocalizedStrings(
-                                "NB Test euDataThemes > title",
-                                "NN Test euDataThemes > title",
-                                "EN Test euDataThemes > title"),
-                        code = "REGI")
-        ),
-        losTheme = listOf(
-                LosNode(
-                        name = LocalizedStrings(
-                                "NB Test losTheme > name",
-                                "NN Test losTheme > name",
-                                "EN Test losTheme > name"),
-                        losPaths = listOf("test"),
-                )
-        ),
-        spatial = listOf(
-                ReferenceDataCode(
-                        uri = "Test spatial > uri",
-                        code = "Test spatial > code",
-                        prefLabel = LocalizedStrings(
-                                "NB Test spatial > prefLabel",
-                                "NN Test spatial > prefLabel",
-                                "EN Test spatial > prefLabel"),
-                )
-        ),
-        harvest =  HarvestMetadata(
-            "2022-02-15T11:00:05Z",
-                listOf("Test harvest > changed")),
+    ),
+    description = LocalizedStrings(
+        "NB Test description",
+        "NN Test description",
+        "NO Test description",
+        "EN Test description"),
+    keyword = listOf(
+        LocalizedStrings(
+            "NB Test keyword",
+            "NN Test keyword",
+            "NO Test keyword",
+            "EN Test keyword")
+    ),
+    euDataThemes = listOf(
+        EuDataTheme(
+            title = LocalizedStrings(
+                "NB Test euDataThemes > title",
+                "NN Test euDataThemes > title",
+                "NO Test euDataThemes > title",
+                "EN Test euDataThemes > title"),
+            code = "ENVI"),
+        EuDataTheme(
+            title = LocalizedStrings(
+                "NB Test euDataThemes > title",
+                "NN Test euDataThemes > title",
+                "NO Test euDataThemes > title",
+                "EN Test euDataThemes > title"),
+            code = "REGI")
+    ),
+    losTheme = listOf(
+        LosNode(
+            name = LocalizedStrings(
+                "NB Test losTheme > name",
+                "NN Test losTheme > name",
+                "NO Test losTheme > name",
+                "EN Test losTheme > name"),
+            losPaths = listOf("test"),
+        )
+    ),
+    spatial = listOf(
+        ReferenceDataCode(
+            uri = "Test spatial > uri",
+            code = "Test spatial > code",
+            prefLabel = LocalizedStrings(
+                "NB Test spatial > prefLabel",
+                "NN Test spatial > prefLabel",
+                "NO Test spatial > prefLabel",
+                "EN Test spatial > prefLabel"),
+        )
+    ),
+    harvest = HarvestMetadata(
+        "2022-02-15T11:00:05Z",
+        listOf("Test harvest > changed")),
 )
 
 val TEST_SERVICE_HIT_OWNED_BY = TEST_SERVICE_HIT_ALL_FIELDS.copy(
-        uri = "uri 0102",
-        keyword = listOf( LocalizedStrings(nb = "keyword", nn = "keyword", en = "keyword" )),
-        ownedBy = listOf( Organization(
-                orgPath = "/STAT/010247858",
-                identifier = "test identifier 0102",
-                uri = "test uri 0102",
-                name = "test name 0102",
-                prefLabel = LocalizedStrings(
-                        "NB Test ownedBy > prefLabel",
-                        "NN Test ownedBy > prefLabel",
-                        "EN Test ownedBy > prefLabel"),
-        ))
+    uri = "uri 0102",
+    keyword = listOf(LocalizedStrings(nb = "keyword", nn = "keyword", no = "keyword", en = "keyword")),
+    ownedBy = listOf(Organization(
+        orgPath = "/STAT/010247858",
+        identifier = "test identifier 0102",
+        uri = "test uri 0102",
+        name = "test name 0102",
+        prefLabel = LocalizedStrings(
+            "NB Test ownedBy > prefLabel",
+            "NN Test ownedBy > prefLabel",
+            "NO Test ownedBy > prefLabel",
+            "EN Test ownedBy > prefLabel"),
+    ))
 )
 
-val TEST_SERVICE_HIT_HAS_COMPETANT_AUTHORITY =  TEST_NULL_SERVICE.copy(
-        uri = "uri 0103",
-        hasCompetantAuthority = listOf( Organization(
-                orgPath = "/STAT/103417858",
-                identifier = "test identifier 0103",
-                uri = "test uri 0103",
-                name = "test name 0103",
-                prefLabel = LocalizedStrings(
-                        "NB Test hasCompetantAuthority > prefLabel",
-                        "NN Test hasCompetantAuthority > prefLabel",
-                        "EN Test hasCompetantAuthority > prefLabel"),
-        ))
+val TEST_SERVICE_HIT_HAS_COMPETANT_AUTHORITY = TEST_NULL_SERVICE.copy(
+    uri = "uri 0103",
+    hasCompetantAuthority = listOf(Organization(
+        orgPath = "/STAT/103417858",
+        identifier = "test identifier 0103",
+        uri = "test uri 0103",
+        name = "test name 0103",
+        prefLabel = LocalizedStrings(
+            "NB Test hasCompetantAuthority > prefLabel",
+            "NN Test hasCompetantAuthority > prefLabel",
+            "NO Test hasCompetantAuthority > prefLabel",
+            "EN Test hasCompetantAuthority > prefLabel"),
+    ))
 )
 
 val SERVICE_WITH_RELATIONS = TEST_NULL_SERVICE.copy(


### PR DESCRIPTION
En del ressurser mangler tittel i search-service fordi de bare har data i `no`-feltet, feks datasettet med fdkId `c75f377e-76d1-352d-8cd9-bf1c445b9efb`, hvor title har verdien:
`
"title": {
  "no": "Jordsmonn - WRB-grupper"
}
`