### PR TITLE
Fix/jr/suggestion order

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/controller/SearchController.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/controller/SearchController.kt
@@ -42,3 +42,4 @@ class SearchController(
         }
     }
 }
+

--- a/src/main/kotlin/no/digdir/fdk/searchservice/controller/SuggestionsController.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/controller/SuggestionsController.kt
@@ -1,6 +1,7 @@
 package no.digdir.fdk.searchservice.controller
 
 import no.digdir.fdk.searchservice.mapper.pathVariableToSearchType
+import no.digdir.fdk.searchservice.model.SearchProfile
 import no.digdir.fdk.searchservice.model.SuggestionsResult
 import no.digdir.fdk.searchservice.service.SuggestionService
 import org.springframework.http.HttpStatus
@@ -14,27 +15,25 @@ class SuggestionsController(
 ) {
     @GetMapping
     fun suggestResource(
-        @RequestParam(
-            value = "q"
-        ) query: String,
+        @RequestParam(value = "q") query: String,
+        @RequestParam(value = "profile") searchProfile: SearchProfile?,
     ): ResponseEntity<SuggestionsResult> =
         ResponseEntity(
-            suggestionService.suggestResources(query, null),
+            suggestionService.suggestResources(query, null, searchProfile),
             HttpStatus.OK
         )
 
-    @GetMapping(
-        value = ["/{searchTypes}"]
-    )
+    @GetMapping(value = ["/{searchTypes}"])
     fun suggestionsForSpecificResource(
         @PathVariable searchTypes: String,
         @RequestParam("q") query: String,
+        @RequestParam("profile") searchProfile: SearchProfile?,
     ): ResponseEntity<SuggestionsResult> = (
         if (searchTypes.pathVariableToSearchType() == null) {
             ResponseEntity.notFound().build()
         } else {
             ResponseEntity(
-                suggestionService.suggestResources(query, searchTypes.pathVariableToSearchType()),
+                suggestionService.suggestResources(query, searchTypes.pathVariableToSearchType(), searchProfile),
                 HttpStatus.OK
             )
         })

--- a/src/main/kotlin/no/digdir/fdk/searchservice/service/SearchService.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/service/SearchService.kt
@@ -400,64 +400,62 @@ class SearchService(
                     )
                 )
             }
+}
 
-    private val transportProfileLosValues =
+private val transportProfileLosValues =
         listOf(
-            FieldValue.of("trafikk-og-transport/mobilitetstilbud"),
-            FieldValue.of("trafikk-og-transport/trafikkinformasjon"),
-            FieldValue.of("trafikk-og-transport/veg-og-vegregulering"),
-            FieldValue.of("trafikk-og-transport/yrkestransport"),
+                FieldValue.of("trafikk-og-transport/mobilitetstilbud"),
+                FieldValue.of("trafikk-og-transport/trafikkinformasjon"),
+                FieldValue.of("trafikk-og-transport/veg-og-vegregulering"),
+                FieldValue.of("trafikk-og-transport/yrkestransport"),
         )
-
-    private fun filtersForProfile(profile: SearchProfile) = when(profile) {
-        SearchProfile.TRANSPORT -> {
-            co.elastic.clients.elasticsearch._types.query_dsl.Query.of { queryBuilder ->
-                queryBuilder.terms { termsBuilder ->
-                    termsBuilder
+internal fun filtersForProfile(profile: SearchProfile) = when(profile) {
+    SearchProfile.TRANSPORT -> {
+        co.elastic.clients.elasticsearch._types.query_dsl.Query.of { queryBuilder ->
+            queryBuilder.terms { termsBuilder ->
+                termsBuilder
                         .field(FilterFields.LosTheme.jsonPath())
                         .terms { termsQueryBuilder ->
                             termsQueryBuilder.value(transportProfileLosValues)
                         }
-                }
             }
         }
     }
-
-    private fun FilterFields.jsonPath(): String = when(this) {
-        FilterFields.AccessRights -> "accessRights.code.keyword"
-        FilterFields.DataTheme -> "dataTheme.code.keyword"
-        FilterFields.Deleted -> "metadata.deleted"
-        FilterFields.FirstHarvested -> "metadata.firstHarvested"
-        FilterFields.Format -> "fdkFormatPrefixed.keyword"
-        FilterFields.LosTheme -> "losTheme.losPaths.keyword"
-        FilterFields.OpenData -> "isOpenData"
-        FilterFields.OrgPath -> "organization.orgPath.keyword"
-        FilterFields.Provenance -> "provenance.code.keyword"
-        FilterFields.Relations -> "relations.uri.keyword"
-        FilterFields.SearchType -> "searchType.keyword"
-        FilterFields.Spatial -> "spatial.prefLabel.nb.keyword"
-        FilterFields.Uri -> "uri.keyword"
-    }
-
-    private fun FilterFields.aggregationName(): String = when(this) {
-        FilterFields.AccessRights -> "accessRights"
-        FilterFields.DataTheme -> "dataTheme"
-        FilterFields.Deleted -> "deleted"
-        FilterFields.FirstHarvested -> "firstHarvested"
-        FilterFields.Format -> "format"
-        FilterFields.LosTheme -> "losTheme"
-        FilterFields.OpenData -> "openData"
-        FilterFields.OrgPath -> "orgPath"
-        FilterFields.Provenance -> "provenance"
-        FilterFields.Relations -> "relations"
-        FilterFields.SearchType -> "searchType"
-        FilterFields.Spatial -> "spatial"
-        FilterFields.Uri -> "uri"
-    }
-
 }
 
-private enum class FilterFields {
+internal enum class FilterFields {
     AccessRights, DataTheme, Deleted, FirstHarvested, Format, LosTheme,
     OpenData, OrgPath, Provenance, Relations, SearchType, Spatial, Uri
+}
+
+internal fun FilterFields.jsonPath(): String = when(this) {
+    FilterFields.AccessRights -> "accessRights.code.keyword"
+    FilterFields.DataTheme -> "dataTheme.code.keyword"
+    FilterFields.Deleted -> "metadata.deleted"
+    FilterFields.FirstHarvested -> "metadata.firstHarvested"
+    FilterFields.Format -> "fdkFormatPrefixed.keyword"
+    FilterFields.LosTheme -> "losTheme.losPaths.keyword"
+    FilterFields.OpenData -> "isOpenData"
+    FilterFields.OrgPath -> "organization.orgPath.keyword"
+    FilterFields.Provenance -> "provenance.code.keyword"
+    FilterFields.Relations -> "relations.uri.keyword"
+    FilterFields.SearchType -> "searchType.keyword"
+    FilterFields.Spatial -> "spatial.prefLabel.nb.keyword"
+    FilterFields.Uri -> "uri.keyword"
+}
+
+private fun FilterFields.aggregationName(): String = when(this) {
+    FilterFields.AccessRights -> "accessRights"
+    FilterFields.DataTheme -> "dataTheme"
+    FilterFields.Deleted -> "deleted"
+    FilterFields.FirstHarvested -> "firstHarvested"
+    FilterFields.Format -> "format"
+    FilterFields.LosTheme -> "losTheme"
+    FilterFields.OpenData -> "openData"
+    FilterFields.OrgPath -> "orgPath"
+    FilterFields.Provenance -> "provenance"
+    FilterFields.Relations -> "relations"
+    FilterFields.SearchType -> "searchType"
+    FilterFields.Spatial -> "spatial"
+    FilterFields.Uri -> "uri"
 }

--- a/src/test/kotlin/no/digdir/fdk/searchservice/integration/SuggestionTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/integration/SuggestionTest.kt
@@ -115,6 +115,20 @@ class SuggestionTest: ApiTestContext() {
         }
 
         @Test
+        fun `get suggestion with transport profile`() {
+            val response = requestApi("$SUGGESTIONS_PATH/datasets?q=title&profile=TRANSPORT", port, null, GET)
+            Assertions.assertEquals(200, response["status"])
+
+            val result: SuggestionsResult = mapper.readValue(response["body"] as String)
+            Assertions.assertEquals(2, result.suggestions.size)
+
+            val validResult = result.suggestions.all { resource ->
+                resource.title?.nb?.contains("NB Test title") == true && resource.searchType == SearchType.DATASET
+            }
+            Assertions.assertTrue(validResult)
+        }
+
+        @Test
         fun `non valid resource type should return not found`() {
             val response = requestApi("$SUGGESTIONS_PATH/nonvalid?q=title", port, null, GET)
             Assertions.assertEquals(404, response["status"])


### PR DESCRIPTION
Suggestion matches are not ordered correctly. This is because of prefix query. By adding the phrase query we solve this issue. Also added support for profile for suggestions.