### PR TITLE
fix: use correct field type for Service.spatial

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
@@ -18,7 +18,7 @@ fun Service.toSearchObject(id: String, timestamp: Long, deleted: Boolean = false
         organization = getOrganization()?.toSearchOrg(),
         provenance = null,
         searchType = SearchType.SERVICE,
-        spatial = spatial?.toSet(),
+        spatial = spatial?.map { ReferenceDataCode(uri = it, code = null, prefLabel = null) }?.toSet(),
         title = title,
         relations = getRelations(),
         specializedType = null,

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
@@ -13,7 +13,7 @@ data class Service(
     val losTheme: List<LosNode>?,
     val ownedBy: List<ServiceOrganization>?,
     val hasCompetentAuthority: List<ServiceOrganization>?,
-    val spatial: List<ReferenceDataCode>?,
+    val spatial: List<String>?,
     val harvest: HarvestMetadata?,
     val isGroupedBy: List<String>?,
     val isClassifiedBy: List<ObjectWithURI>?,

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
@@ -108,17 +108,7 @@ val TEST_SERVICE_HIT_ALL_FIELDS = TEST_NULL_SERVICE.copy(
             losPaths = listOf("test"),
         )
     ),
-    spatial = listOf(
-        ReferenceDataCode(
-            uri = "Test spatial > uri",
-            code = "Test spatial > code",
-            prefLabel = LocalizedStrings(
-                "NB Test spatial > prefLabel",
-                "NN Test spatial > prefLabel",
-                "NO Test spatial > prefLabel",
-                "EN Test spatial > prefLabel"),
-        )
-    ),
+    spatial = listOf("Test spatial > uri"),
     harvest = HarvestMetadata(
         "2022-02-15T11:00:05Z",
         "2022-02-15T11:00:05Z"),


### PR DESCRIPTION
ref: https://github.com/Informasjonsforvaltning/fdk-rdf-parser/blob/main/src/fdk_rdf_parser/classes/cpsvno_service.py#L42

typen til `spatial` på tjenester er `List<String>`, derfor vil search-service per nå stoppe helt opp hvis en tjeneste med definert spatial blir høsta. Det har heldigvis bare skjedd i demo så langt 👍 