### PR TITLE
chore: update service model

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
@@ -38,8 +38,8 @@ private fun ServiceOrganization.toSearchOrg(): Organization =
         id = identifier,
         uri = uri,
         orgPath = orgPath,
-        name = name?.nb,
-        prefLabel = title
+        name = title?.nb ?: prefLabel?.nb,
+        prefLabel = prefLabel ?: title
     )
 
 

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
@@ -28,6 +28,6 @@ data class ServiceOrganization(
     val identifier: String?,
     val uri: String?,
     val orgPath: String?,
-    val name: LocalizedStrings?,
+    val prefLabel: LocalizedStrings?,
     val title: LocalizedStrings?,
 )

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
@@ -121,7 +121,7 @@ val TEST_SERVICE_HIT_OWNED_BY = TEST_SERVICE_HIT_ALL_FIELDS.copy(
         orgPath = "/STAT/010247858",
         identifier = "test identifier 0102",
         uri = "test uri 0102",
-        name = LocalizedStrings("test name 0102", null, null, null),
+        prefLabel = LocalizedStrings("test name 0102", null, null, null),
         title = LocalizedStrings(
             "NB Test ownedBy > prefLabel",
             "NN Test ownedBy > prefLabel",
@@ -136,7 +136,7 @@ val TEST_SERVICE_HIT_HAS_COMPETENT_AUTHORITY = TEST_NULL_SERVICE.copy(
         orgPath = "/STAT/103417858",
         identifier = "test identifier 0103",
         uri = "test uri 0103",
-        name = LocalizedStrings("test name 0103", null, null, null),
+        prefLabel = LocalizedStrings("test name 0103", null, null, null),
         title = LocalizedStrings(
             "NB Test hasCompetentAuthority > prefLabel",
             "NN Test hasCompetentAuthority > prefLabel",


### PR DESCRIPTION
Er pga endringer i ny parser-service, har samkjørt strukturen til organisasjoner som er definert for tjenester med de som er definert som publisher for andre ressurser