### PR TITLE
feat: add specializedType support for services

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/mapper/ServiceMapper.kt
@@ -21,7 +21,7 @@ fun Service.toSearchObject(id: String, timestamp: Long, deleted: Boolean = false
         spatial = spatial?.toSet(),
         title = title,
         relations = getRelations(),
-        specializedType = null,
+        specializedType = getSpecializedType(),
         isAuthoritative = null,
         isRelatedToTransportportal = false,
         additionalTitles = null
@@ -71,4 +71,12 @@ fun Service.getRelations(): Set<Relation> {
     }
 
     return relations
+}
+
+fun Service.getSpecializedType(): SpecializedType? {
+    return when (specializedType) {
+        "publicService" -> SpecializedType.PUBLIC_SERVICE
+        "service" -> SpecializedType.SERVICE
+        else -> null
+    }
 }

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonEnumClasses.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonEnumClasses.kt
@@ -1,5 +1,7 @@
 package no.digdir.fdk.searchservice.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 enum class SearchType {
     CONCEPT,
     DATASET,
@@ -19,6 +21,6 @@ enum class SpecializedType {
     DATASET_SERIES,
     LIFE_EVENT,
     BUSINESS_EVENT,
-    PUBLIC_SERVICE,
-    SERVICE,
+    @JsonProperty("publicService") PUBLIC_SERVICE,
+    @JsonProperty("service") SERVICE,
 }

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonEnumClasses.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/CommonEnumClasses.kt
@@ -19,4 +19,6 @@ enum class SpecializedType {
     DATASET_SERIES,
     LIFE_EVENT,
     BUSINESS_EVENT,
+    PUBLIC_SERVICE,
+    SERVICE,
 }

--- a/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
+++ b/src/main/kotlin/no/digdir/fdk/searchservice/model/Service.kt
@@ -20,7 +20,8 @@ data class Service(
     val isDescribedAt: List<ObjectWithURI>?,
     val relation: List<ObjectWithURI>?,
     val requires: List<ObjectWithURI>?,
-    val subject: List<ObjectWithURI>?
+    val subject: List<ObjectWithURI>?,
+    val specializedType: String?
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/data/ServiceTestData.kt
@@ -19,7 +19,8 @@ val TEST_NULL_SERVICE = Service(
     requires = null,
     isDescribedAt = null,
     isGroupedBy = null,
-    isClassifiedBy = null
+    isClassifiedBy = null,
+    specializedType = null
 )
 
 val TEST_SERVICE = TEST_NULL_SERVICE.copy(

--- a/src/test/kotlin/no/digdir/fdk/searchservice/unit/SpecializedTypeTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/unit/SpecializedTypeTest.kt
@@ -2,6 +2,7 @@ package no.digdir.fdk.searchservice.unit
 
 import no.digdir.fdk.searchservice.data.TEST_NULL_DATASET
 import no.digdir.fdk.searchservice.data.TEST_NULL_EVENT
+import no.digdir.fdk.searchservice.data.TEST_NULL_SERVICE
 import no.digdir.fdk.searchservice.mapper.toSearchObject
 import no.digdir.fdk.searchservice.model.SpecializedType
 import org.junit.jupiter.api.Nested
@@ -34,6 +35,21 @@ class SpecializedTypeTest {
         fun `life event to search object has correct specialized type`() {
             val businessEvent = TEST_NULL_EVENT.copy(uri = "test", specializedType = "life_event")
             assertEquals(SpecializedType.LIFE_EVENT, businessEvent.toSearchObject("test", 0).specializedType)
+        }
+    }
+
+    @Nested
+    internal inner class Service {
+        @Test
+        fun `public service to search object has correct specialized type`() {
+            val publicService = TEST_NULL_SERVICE.copy(uri = "test", specializedType = "publicService")
+            assertEquals(SpecializedType.PUBLIC_SERVICE, publicService.toSearchObject("test", 0).specializedType)
+        }
+
+        @Test
+        fun `generic service to search object has correct specialized type`() {
+            val genericService = TEST_NULL_SERVICE.copy(uri = "test", specializedType = "service")
+            assertEquals(SpecializedType.SERVICE, genericService.toSearchObject("test", 0).specializedType)
         }
     }
 }

--- a/src/test/kotlin/no/digdir/fdk/searchservice/unit/SpecializedTypeTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/searchservice/unit/SpecializedTypeTest.kt
@@ -1,5 +1,6 @@
 package no.digdir.fdk.searchservice.unit
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.digdir.fdk.searchservice.data.TEST_NULL_DATASET
 import no.digdir.fdk.searchservice.data.TEST_NULL_EVENT
 import no.digdir.fdk.searchservice.data.TEST_NULL_SERVICE
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 
 @Tag("unit")
@@ -50,6 +52,20 @@ class SpecializedTypeTest {
         fun `generic service to search object has correct specialized type`() {
             val genericService = TEST_NULL_SERVICE.copy(uri = "test", specializedType = "service")
             assertEquals(SpecializedType.SERVICE, genericService.toSearchObject("test", 0).specializedType)
+        }
+
+        @Test
+        fun `public service serializes to camelCase JSON`() {
+            val searchObject = TEST_NULL_SERVICE.copy(uri = "test", specializedType = "publicService").toSearchObject("test", 0)
+            val json = jacksonObjectMapper().writeValueAsString(searchObject)
+            assertTrue(json.contains("\"specializedType\":\"publicService\""))
+        }
+
+        @Test
+        fun `generic service serializes to camelCase JSON`() {
+            val searchObject = TEST_NULL_SERVICE.copy(uri = "test", specializedType = "service").toSearchObject("test", 0)
+            val json = jacksonObjectMapper().writeValueAsString(searchObject)
+            assertTrue(json.contains("\"specializedType\":\"service\""))
         }
     }
 }


### PR DESCRIPTION
# Summary

- Add `PUBLIC_SERVICE` and `SERVICE` values to `SpecializedType` enum
- Add `specializedType: String?` field to `Service` model so Jackson deserializes it from upstream JSON
- Map `"publicService"` → `PUBLIC_SERVICE` and `"service"` → `SERVICE` in `ServiceMapper`; unknown/missing values fall through to `null`
- Add unit tests for both mappings in `SpecializedTypeTest`